### PR TITLE
[README] yan을 yarn으로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ await getBank.request(iamport)
 
 
 ## 테스트하기
-프로젝트를 클론 받은 후 필요한 모듈을 설치합니다. yan example 명령어를 통해 테스트할 타깃, `REST API 키` 그리고 `REST API SECRET 키`를 입력합니다.
+프로젝트를 클론 받은 후 필요한 모듈을 설치합니다. yarnexample 명령어를 통해 테스트할 타깃, `REST API 키` 그리고 `REST API SECRET 키`를 입력합니다.
 
 ```
 $ git clone https://github.com/SoleeChoi/iamport-rest-client-nodejs.git


### PR DESCRIPTION
## 요약

README의 `yan example` -> `yarn example`로 오탈자 수정합니다.
명령어가 `yarn`이어야 합니다.

![스크린샷 2021-12-16 오전 11 05 59](https://user-images.githubusercontent.com/33085082/146294680-7968231c-90df-404c-9ada-f443c652be3b.png)

