### PR TITLE
Subscribe / Schedule 모델과 인터페이스 최신화

### DIFF
--- a/lib/request/Subscribe.ts
+++ b/lib/request/Subscribe.ts
@@ -9,6 +9,7 @@ interface ScheduleInfo {
   merchant_uid: string,
   schedule_at: number,
   amount: number,
+  currency?: string,
   tax_free?: number,
   name?: string,
   buyer_name?: string,
@@ -18,15 +19,19 @@ interface ScheduleInfo {
   buyer_postcode?: string,
   custom_data?: string,
   notice_url?: string,
+  // TODO: 타입을 더 구체적으로 명시하기
+  extra?: { [key: string]: any } | any[],
 };
 interface onetimeData {
   merchant_uid: string,
+  currency?: string,
   amount: number,
   tax_free?: number,
   card_number: string,
   expiry: string,
   birth: string,
   pwd_2digit?: string,
+  cvc?: string,
   customer_uid?: string,
   pg?: string,
   name: string,
@@ -39,10 +44,13 @@ interface onetimeData {
   card_quota?: number,
   custom_data?: string,
   notice_url?: string,
+  secure_3d_charge_id?: string,
+  secure_3d_token?: string,
 };
 interface againData {
   customer_uid: string,
   merchant_uid: string,
+  currency?: string,
   amount: number,
   tax_free?: number,
   name: string,
@@ -52,6 +60,7 @@ interface againData {
   buyer_addr?: string,
   buyer_postcode?: string,
   interest_free_by_merchant?: boolean,
+  use_card_point?: boolean,
   card_quota?: number,
   custom_data?: string,
   notice_url?: string,
@@ -63,6 +72,7 @@ interface ScheduleData {
   expiry?: string,
   birth?: string,
   pwd_2digit?: string,
+  cvc?: string,
   pg?: string,
   schedules: ScheduleInfo[],
 };

--- a/lib/response/ScheduledResult.ts
+++ b/lib/response/ScheduledResult.ts
@@ -4,7 +4,10 @@ import { ScheduledStatusEnum } from '../enum';
 class ScheduledResult extends ResponseBase {
   public customer_uid?: string;
   public merchant_uid?: string;
+  public imp_uid?: string;
   public schedule_at?: Date | number;
+  public executed_at?: Date | number;
+  public revoked_at?: Date | number;
   public amount?: number;
   public name?: string;
   public buyer_name?: string;
@@ -14,12 +17,17 @@ class ScheduledResult extends ResponseBase {
   public buyer_postcode?: string;
   public custom_data?: string;
   public schedule_status?: ScheduledStatusEnum;
+  public payment_status?: 'paid' | 'failed' | 'cancelled';
+  public fail_reason?: string;
 
   public setAttributes(response: ScheduledResult): void {
     const {
       customer_uid,
       merchant_uid,
+      imp_uid,
       schedule_at,
+      executed_at,
+      revoked_at,
       amount,
       name,
       buyer_name,
@@ -29,11 +37,16 @@ class ScheduledResult extends ResponseBase {
       buyer_postcode,
       custom_data,
       schedule_status,
+      payment_status,
+      fail_reason,
     } = response;
 
     this.customer_uid = customer_uid;
     this.merchant_uid = merchant_uid;
+    this.imp_uid = imp_uid;
     this.schedule_at = this.timeToDate(schedule_at);
+    this.executed_at = this.timeToDate(executed_at);
+    this.revoked_at = this.timeToDate(revoked_at);
     this.amount = amount;
     this.name = name;
     this.buyer_name = buyer_name;
@@ -43,6 +56,8 @@ class ScheduledResult extends ResponseBase {
     this.buyer_postcode = buyer_postcode;
     this.custom_data = custom_data;
     this.schedule_status = schedule_status;
+    this.payment_status = payment_status;
+    this.fail_reason = fail_reason;
   }
 }
 


### PR DESCRIPTION
- Related Issue: #5 
- [i'mport REST API document](https://api.iamport.kr/)

## Description

Subscribe / Schedule Request 파라미터와 Response 모델을 최신화합니다.

- `Subscribe.onetime` 인자에 `currency`, `cvc`, `secure_3d_charge_id`, `secure_3d_token` 추가
- `Subscribe.again` 인자에 `currency`, `use_card_point` 추가
- `Subscribe.schedule` 인자에 `cvc`, `schedules.currency`, `schedules.extra` 추가
- `ScheduledResult` 클래스에 `imp_uid`, `executed_at`, `revoked_at`, `payment_status`, `fail_reason` 추가
